### PR TITLE
Require React as a peerDependency to prevent version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "prop-types": "~15.6.0",
-    "react": "~16.2.0",
     "react-dom": "~16.2.0"
   },
   "devDependencies": {
@@ -37,7 +36,11 @@
     "babel-preset-env": "~1.6.0",
     "babel-preset-react": "~6.24.1",
     "babel-preset-react-optimize": "~1.0.1",
+    "react": "~16.2.0",
     "standard": "latest"
+  },
+  "peerDependencies": {
+    "react": ">=15.0.0"
   },
   "engines": {
     "node": ">= 8"


### PR DESCRIPTION
I'd like to include this in a project I'm working on but don't want an extra version of react bundled into my code—would love if we could include it as a peerDependency instead!

https://stackoverflow.com/questions/30451556/what-is-the-correct-way-of-adding-a-dependency-to-react-in-your-package-json-for